### PR TITLE
Fix missing header include and session duplication

### DIFF
--- a/login.php
+++ b/login.php
@@ -1,7 +1,6 @@
 <?php
 require_once 'includes/config.php';
 require_once 'controllers/AuthController.php';
-session_start();
 
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/purchase.php
+++ b/purchase.php
@@ -1,7 +1,6 @@
 <?php
 require_once 'includes/config.php';
 require_once 'controllers/PaymentController.php';
-session_start();
 
 // Kiểm tra đăng nhập
 if (!isset($_SESSION['user_id'])) {

--- a/views/course_detail.view.php
+++ b/views/course_detail.view.php
@@ -12,12 +12,7 @@
 <body class="bg-white text-gray-800">
 
 <!-- Header (reusable include if needed) -->
-<header class="navbar bg-white shadow-md sticky top-0 z-40">
-  <div class="container mx-auto px-4 flex justify-between items-center py-2">
-    <a href="index.php" class="text-xl font-bold text-blue-900">Nihongo Learn</a>
-    <a href="index.php" class="btn btn-ghost">Trang chủ</a>
-  </div>
-</header>
+<?php include __DIR__ . '/partials/header.php'; ?>
 
 <!-- Course Detail Section -->
 <main class="container mx-auto px-4 py-8">

--- a/views/home.view.php
+++ b/views/home.view.php
@@ -13,36 +13,7 @@
 <body class="bg-white text-gray-800">
 
 <!-- Header -->
-<header class="navbar bg-white fixed top-0 left-0 right-0 z-50 shadow">
-  <div class="container mx-auto px-4 flex justify-between items-center">
-    <a href="index.php" class="text-xl font-bold text-blue-900">Nihongo Learn</a>
-    <div class="hidden md:flex space-x-4">
-      <a href="index.php" class="btn btn-ghost">Trang chủ</a>
-      <a href="course.php" class="btn btn-ghost">Khóa học</a>
-      <a href="#contact" class="btn btn-ghost">Liên hệ</a>
-      <?php if (!isset($_SESSION['user_id'])): ?>
-        <a href="login.php" class="btn btn-outline btn-primary">Đăng nhập</a>
-      <?php else: ?>
-        <a href="logout.php" class="btn btn-outline btn-error">Đăng xuất</a>
-      <?php endif; ?>
-    </div>
-    <div class="md:hidden">
-      <details class="dropdown">
-        <summary class="btn btn-ghost">☰</summary>
-        <ul class="menu dropdown-content p-2 shadow bg-base-100 rounded-box w-52">
-          <li><a href="index.php">Trang chủ</a></li>
-          <li><a href="course.php">Khóa học</a></li>
-          <li><a href="#contact">Liên hệ</a></li>
-          <?php if (!isset($_SESSION['user_id'])): ?>
-            <li><a href="login.php">Đăng nhập</a></li>
-          <?php else: ?>
-            <li><a href="logout.php">Đăng xuất</a></li>
-          <?php endif; ?>
-        </ul>
-      </details>
-    </div>
-  </div>
-</header>
+<?php include __DIR__ . '/partials/header.php'; ?>
 
 <!-- Hero Section -->
 <section class="pt-24 pb-12 bg-gradient-to-r from-red-100 via-white to-blue-100 text-center">

--- a/views/partials/header.php
+++ b/views/partials/header.php
@@ -1,0 +1,31 @@
+<header class="navbar bg-white fixed top-0 left-0 right-0 z-50 shadow">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="/index.php" class="text-xl font-bold text-blue-900">Nihongo Learn</a>
+    <div class="hidden md:flex space-x-4">
+      <a href="/index.php" class="btn btn-ghost">Trang chủ</a>
+      <a href="/course.php" class="btn btn-ghost">Khóa học</a>
+      <a href="/index.php#contact" class="btn btn-ghost">Liên hệ</a>
+      <?php if (!isset($_SESSION['user_id'])): ?>
+        <a href="/login.php" class="btn btn-outline btn-primary">Đăng nhập</a>
+      <?php else: ?>
+        <a href="/logout.php" class="btn btn-outline btn-error">Đăng xuất</a>
+      <?php endif; ?>
+    </div>
+    <div class="md:hidden">
+      <details class="dropdown">
+        <summary class="btn btn-ghost">☰</summary>
+        <ul class="menu dropdown-content p-2 shadow bg-base-100 rounded-box w-52">
+          <li><a href="/index.php">Trang chủ</a></li>
+          <li><a href="/course.php">Khóa học</a></li>
+          <li><a href="/index.php#contact">Liên hệ</a></li>
+          <?php if (!isset($_SESSION['user_id'])): ?>
+            <li><a href="/login.php">Đăng nhập</a></li>
+          <?php else: ?>
+            <li><a href="/logout.php">Đăng xuất</a></li>
+          <?php endif; ?>
+        </ul>
+      </details>
+    </div>
+  </div>
+</header>
+

--- a/views/profile.view.php
+++ b/views/profile.view.php
@@ -10,7 +10,7 @@
 <body class="bg-gray-50 text-gray-900">
 
   <!-- Header -->
-  <?php include 'partials/header.php'; ?>
+  <?php include __DIR__ . '/partials/header.php'; ?>
 
   <div class="container mx-auto px-4 pt-24 pb-10 max-w-2xl">
     <h2 class="text-2xl font-bold mb-6 text-blue-800">Thông tin tài khoản</h2>


### PR DESCRIPTION
## Summary
- remove duplicate `session_start()` from login & purchase pages
- add reusable header partial
- fix profile view to load the new header

## Testing
- `php -l login.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d8fbb11748329acc840191afb9944