### PR TITLE
Add account info link

### DIFF
--- a/partials/header.php
+++ b/partials/header.php
@@ -1,0 +1,33 @@
+<header class="navbar bg-white fixed top-0 left-0 right-0 z-50 shadow">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.php" class="text-xl font-bold text-blue-900">Nihongo Learn</a>
+    <div class="hidden md:flex space-x-4">
+      <a href="index.php" class="btn btn-ghost">Trang chủ</a>
+      <a href="course.php" class="btn btn-ghost">Khóa học</a>
+      <a href="#contact" class="btn btn-ghost">Liên hệ</a>
+      <?php if (isset($_SESSION['user_id'])): ?>
+        <a href="profile.php" class="btn btn-ghost">Tài khoản</a>
+        <a href="logout.php" class="btn btn-outline btn-error">Đăng xuất</a>
+      <?php else: ?>
+        <a href="login.php" class="btn btn-outline btn-primary">Đăng nhập</a>
+      <?php endif; ?>
+    </div>
+    <div class="md:hidden">
+      <details class="dropdown">
+        <summary class="btn btn-ghost">☰</summary>
+        <ul class="menu dropdown-content p-2 shadow bg-base-100 rounded-box w-52">
+          <li><a href="index.php">Trang chủ</a></li>
+          <li><a href="course.php">Khóa học</a></li>
+          <li><a href="#contact">Liên hệ</a></li>
+          <?php if (isset($_SESSION['user_id'])): ?>
+            <li><a href="profile.php">Tài khoản</a></li>
+            <li><a href="logout.php">Đăng xuất</a></li>
+          <?php else: ?>
+            <li><a href="login.php">Đăng nhập</a></li>
+          <?php endif; ?>
+        </ul>
+      </details>
+    </div>
+  </div>
+</header>
+

--- a/views/course_detail.view.php
+++ b/views/course_detail.view.php
@@ -15,7 +15,15 @@
 <header class="navbar bg-white shadow-md sticky top-0 z-40">
   <div class="container mx-auto px-4 flex justify-between items-center py-2">
     <a href="index.php" class="text-xl font-bold text-blue-900">Nihongo Learn</a>
-    <a href="index.php" class="btn btn-ghost">Trang chủ</a>
+    <div class="flex space-x-2">
+      <a href="index.php" class="btn btn-ghost">Trang chủ</a>
+      <?php if (isset($_SESSION['user_id'])): ?>
+        <a href="profile.php" class="btn btn-ghost">Tài khoản</a>
+        <a href="logout.php" class="btn btn-outline btn-error">Đăng xuất</a>
+      <?php else: ?>
+        <a href="login.php" class="btn btn-outline btn-primary">Đăng nhập</a>
+      <?php endif; ?>
+    </div>
   </div>
 </header>
 

--- a/views/course_detail.view.php
+++ b/views/course_detail.view.php
@@ -11,21 +11,8 @@
 </head>
 <body class="bg-white text-gray-800">
 
-<!-- Header (reusable include if needed) -->
-<header class="navbar bg-white shadow-md sticky top-0 z-40">
-  <div class="container mx-auto px-4 flex justify-between items-center py-2">
-    <a href="index.php" class="text-xl font-bold text-blue-900">Nihongo Learn</a>
-    <div class="flex space-x-2">
-      <a href="index.php" class="btn btn-ghost">Trang chủ</a>
-      <?php if (isset($_SESSION['user_id'])): ?>
-        <a href="profile.php" class="btn btn-ghost">Tài khoản</a>
-        <a href="logout.php" class="btn btn-outline btn-error">Đăng xuất</a>
-      <?php else: ?>
-        <a href="login.php" class="btn btn-outline btn-primary">Đăng nhập</a>
-      <?php endif; ?>
-    </div>
-  </div>
-</header>
+<!-- Header -->
+<?php include 'partials/header.php'; ?>
 
 <!-- Course Detail Section -->
 <main class="container mx-auto px-4 py-8">

--- a/views/home.view.php
+++ b/views/home.view.php
@@ -23,6 +23,7 @@
       <?php if (!isset($_SESSION['user_id'])): ?>
         <a href="login.php" class="btn btn-outline btn-primary">Đăng nhập</a>
       <?php else: ?>
+        <a href="profile.php" class="btn btn-ghost">Tài khoản</a>
         <a href="logout.php" class="btn btn-outline btn-error">Đăng xuất</a>
       <?php endif; ?>
     </div>
@@ -36,6 +37,7 @@
           <?php if (!isset($_SESSION['user_id'])): ?>
             <li><a href="login.php">Đăng nhập</a></li>
           <?php else: ?>
+            <li><a href="profile.php">Tài khoản</a></li>
             <li><a href="logout.php">Đăng xuất</a></li>
           <?php endif; ?>
         </ul>

--- a/views/home.view.php
+++ b/views/home.view.php
@@ -13,38 +13,7 @@
 <body class="bg-white text-gray-800">
 
 <!-- Header -->
-<header class="navbar bg-white fixed top-0 left-0 right-0 z-50 shadow">
-  <div class="container mx-auto px-4 flex justify-between items-center">
-    <a href="index.php" class="text-xl font-bold text-blue-900">Nihongo Learn</a>
-    <div class="hidden md:flex space-x-4">
-      <a href="index.php" class="btn btn-ghost">Trang chủ</a>
-      <a href="course.php" class="btn btn-ghost">Khóa học</a>
-      <a href="#contact" class="btn btn-ghost">Liên hệ</a>
-      <?php if (!isset($_SESSION['user_id'])): ?>
-        <a href="login.php" class="btn btn-outline btn-primary">Đăng nhập</a>
-      <?php else: ?>
-        <a href="profile.php" class="btn btn-ghost">Tài khoản</a>
-        <a href="logout.php" class="btn btn-outline btn-error">Đăng xuất</a>
-      <?php endif; ?>
-    </div>
-    <div class="md:hidden">
-      <details class="dropdown">
-        <summary class="btn btn-ghost">☰</summary>
-        <ul class="menu dropdown-content p-2 shadow bg-base-100 rounded-box w-52">
-          <li><a href="index.php">Trang chủ</a></li>
-          <li><a href="course.php">Khóa học</a></li>
-          <li><a href="#contact">Liên hệ</a></li>
-          <?php if (!isset($_SESSION['user_id'])): ?>
-            <li><a href="login.php">Đăng nhập</a></li>
-          <?php else: ?>
-            <li><a href="profile.php">Tài khoản</a></li>
-            <li><a href="logout.php">Đăng xuất</a></li>
-          <?php endif; ?>
-        </ul>
-      </details>
-    </div>
-  </div>
-</header>
+<?php include 'partials/header.php'; ?>
 
 <!-- Hero Section -->
 <section class="pt-24 pb-12 bg-gradient-to-r from-red-100 via-white to-blue-100 text-center">


### PR DESCRIPTION
## Summary
- add shared header with account link for logged in users
- link account page from home and course detail

## Testing
- `php -l views/home.view.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9216ce788329b81c3f6365379dd1